### PR TITLE
Keep line-endings on checkout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text eol=lf
+*.png binary


### PR DESCRIPTION
Fix #1 

Had the same issue as #1 - by telling git to always keep the LF line-endings people will not run into this issue anymore