### PR TITLE
Add support for using comment system other than Disqus

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The following icons are supported, please make sure the `name` filed is exactly 
 
 * Keep your regular pages in the `content` folder. To create a new page, run `hugo new page-title.md`
 * Keep your blog posts in the `content/posts` folder. To create a new post, run `hugo new posts/post-title.md`
-* If you want to use comment system other than **Disqus**, then in `config.toml` create a entry `externalComment = true`. And inside your layout directory, create a folder named `partials/` and inside it create a new file named `comments.html`. Inside that comments.html, you can implement your external comment system(like *staticman*, *utteranc.es* etc).
+* If you want to use comment system other than **Disqus**, then in `config.toml` create a entry `externalComment = true`. And inside your `layout` directory, create a folder named `partials` and inside it create a new file named `comments.html`. Inside that comments.html, you can implement your external comment system(like *staticman*, *utteranc.es* etc).
 
 ## Acknowledgments
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The following icons are supported, please make sure the `name` filed is exactly 
 
 * Keep your regular pages in the `content` folder. To create a new page, run `hugo new page-title.md`
 * Keep your blog posts in the `content/posts` folder. To create a new post, run `hugo new posts/post-title.md`
+* If you want to use comment system other than discuss, then in `config.toml` create a entry `externalComment = true`. And inside your layout directory, create a folder named `partials/` and inside it create a new file named `comments.html`. Inside that comments.html, you can use your external comment system.
 
 ## Acknowledgments
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The following icons are supported, please make sure the `name` filed is exactly 
 
 * Keep your regular pages in the `content` folder. To create a new page, run `hugo new page-title.md`
 * Keep your blog posts in the `content/posts` folder. To create a new post, run `hugo new posts/post-title.md`
-* If you want to use comment system other than discuss, then in `config.toml` create a entry `externalComment = true`. And inside your layout directory, create a folder named `partials/` and inside it create a new file named `comments.html`. Inside that comments.html, you can use your external comment system.
+* If you want to use comment system other than **Disqus**, then in `config.toml` create a entry `externalComment = true`. And inside your layout directory, create a folder named `partials/` and inside it create a new file named `comments.html`. Inside that comments.html, you can use your external comment system.
 
 ## Acknowledgments
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The following icons are supported, please make sure the `name` filed is exactly 
 
 * Keep your regular pages in the `content` folder. To create a new page, run `hugo new page-title.md`
 * Keep your blog posts in the `content/posts` folder. To create a new post, run `hugo new posts/post-title.md`
-* If you want to use comment system other than **Disqus**, then in `config.toml` create a entry `externalComment = true`. And inside your layout directory, create a folder named `partials/` and inside it create a new file named `comments.html`. Inside that comments.html, you can use your external comment system.
+* If you want to use comment system other than **Disqus**, then in `config.toml` create a entry `externalComment = true`. And inside your layout directory, create a folder named `partials/` and inside it create a new file named `comments.html`. Inside that comments.html, you can implement your external comment system(like *staticman*, *utteranc.es* etc).
 
 ## Acknowledgments
 

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -35,6 +35,7 @@ enableEmoji = true  # Shorthand emojis in content files - https://gohugo.io/func
   # gitUrl = "https://github.com/Someone/SomeRepo/commit/" # Prefix of link to the git commit detail page. GitInfo must be enabled.
   justifyContent = false  # Set "text-align: justify" to .content, requires extended version of Hugo
   # bgImg = ""  #  Homepage background-image URL
+  # externalComment = true # Enable external comment system other than Disqus
 
   # Social Icons
   # Check https://github.com/Track3/hermit#social-icons for more info.

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -55,7 +55,7 @@
 			{{ template "_internal/disqus.html" . }}
 		</div>
 		{{- else if .Site.Params.ExternalComment }}
-		    {{ partial "external/comments.html" . }}
+		    {{ partial "comments.html" . }}
 		{{- end }}
 	</main>
 {{ end }}

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -54,6 +54,8 @@
 		<div id="disqus" class="thin">
 			{{ template "_internal/disqus.html" . }}
 		</div>
+		{{- else if .Site.Params.ExternalComment }}
+		    {{ partial "external/comments.html" . }}
 		{{- end }}
 	</main>
 {{ end }}


### PR DESCRIPTION
I don't use disqus. I was hoping to have some support from the theme itself. Right now, I am overriding the `single.html` to accommodate the comment system, but is there a better way to do that then this PR?