### PR TITLE
Modularize analytics and add extra headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ You can modify or add any svg icons in site's `layouts/partials/svg.html`
 
 We only have built-in support for Disqus at the moment, if that doesn't fit your needs, you can just add html to site's `layouts/partials/comments.html`
 
+##### Add extra header
+If you want to load something in every page with header, then you can add them inside site's `layouts/partials/extra-headers.html`.
+
+##### Add custom analytics
+If you prefer to use different analytics system other than google analytics, then add them inside `layouts/partials/analytics.html`.
+
 #### Add custom css
 
 For adding custom css to the theme, you need to assign an array of references in `config.toml` like following:

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ You can modify or add any svg icons in site's `layouts/partials/svg.html`
 We only have built-in support for Disqus at the moment, if that doesn't fit your needs, you can just add html to site's `layouts/partials/comments.html`
 
 ##### Add extra header
-If you want to load something in every page with header, then you can add them inside site's `layouts/partials/extra-headers.html`.
+If you want to load something(like *custom javascript*, *google fonts* etc.) in every page with header, then you can add them inside site's `layouts/partials/extra-headers.html`.
 
 ##### Add custom analytics
 If you prefer to use different analytics system other than google analytics, then add them inside `layouts/partials/analytics.html`.

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -28,6 +28,9 @@
 	{{ range .Site.Params.CustomCSS -}}
 		<link rel="stylesheet" href="{{ . | absURL }}">
 	{{- end }}
+	{{ if templates.Exists "partials/extra-headers.html" -}}
+		{{ partial "extra-headers.html" . }}
+	{{- end }}
 </head>
 
 <body id="page">
@@ -36,7 +39,7 @@
 	{{ block "footer" . -}}{{ end }}
 	{{ $script := resources.Get "js/main.js" | minify | fingerprint -}}
 	<script src="{{ $script.Permalink }}" {{ printf "integrity=%q" $script.Data.Integrity | safeHTMLAttr }}></script>
-	{{ template "_internal/google_analytics_async.html" . }}
+	{{ partial "analytics.html" }}
 </body>
 
 </html>

--- a/layouts/partials/analytics.html
+++ b/layouts/partials/analytics.html
@@ -1,0 +1,1 @@
+{{ template "_internal/google_analytics_async.html" . }}


### PR DESCRIPTION
To be honest, I personally don't prefer to override `baselistof.html` because it is core part of the theme. It might be updated time to time, as the theme is still growing 🌞 . It would be great if we could add support so that if someone wants to customize the theme, they can do it without messing with `baselistof.html`. Hence, adding extra header.

Also, if someone prefers to have different analytics system then Google Analytics, we can allow him/her to do that without touching the `baselistof.html`.

**FYI:** I know, it is not applicable to 99% users of this theme, but it would be a nice feature to have(atleast for myself). 