### PR TITLE
Disable wrapping of text in code blocks, scroll instead

### DIFF
--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -47,8 +47,7 @@ pre {
   font-size: .9em;
   line-height: 1.5;
   letter-spacing: normal;
-  white-space: pre-wrap;
-  word-wrap: break-word;
+  white-space: pre;
   color: #eee;
   background: $midnightblue;
   border-radius: 4px;

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -41,7 +41,6 @@ pre tt {
 }
 
 pre {
-  max-height: 40em;
   padding: .7em 1.1em;
   overflow: auto;
   font-size: .9em;


### PR DESCRIPTION
I turned off word wrapping in `pre` code blocks. It looks strange and usually is not done like this, as far as I can tell. For example, GitHub Wiki doesn't wrap. Here I found an [example](https://github.com/NativeScript/NativeScript/wiki/Migration-Steps-to-NativeScript-5.0#update-nativescript-ui-listview-and-nativescript-ui-sidedrawer-only-if-used-in-your-project), the last code block is long.