### PR TITLE
Changes Title to Site.Title in the head for the website title to show up

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -11,7 +11,7 @@
 	{{- end }}
 	{{- partial "structured-data.html" . }}
 	{{- partial "favicons.html" }}
-	<title>{{.Title}}</title>
+	<title>{{ .Site.Title }}</title>
 	{{ range .AlternativeOutputFormats -}}
 		{{ printf `<link rel="%s" type="%s+%s" href="%s" title="%s" />` .Rel .MediaType.Type .MediaType.Suffix .Permalink $.Site.Title | safeHTML }}
 	{{ end -}}


### PR DESCRIPTION
The site title was not showing up for my installation, upon troubleshooting I realised this is a problem with the base installation when you are not using posts to dictate the title. 

I am not really sure if this change fits all use cases, cause am not really familiar with Hugo. Please feel free to leave a comment to educate me if the case is otherwise :P