### PR TITLE
Improve the contrast between the background and text

### DIFF
--- a/assets/scss/_predefined.scss
+++ b/assets/scss/_predefined.scss
@@ -1,7 +1,7 @@
 // Colors
 //
 $theme: #018574;
-$text: #c6cddb;
+$text: #e8eef2;
 $light-grey: #494f5c;
 $dark-grey: #3B3E48;
 $highlight-grey: #7d828a;


### PR DESCRIPTION
I was finding reading a bit difficult due to the lack of contrast and decided
accessibility was a good metric to decide how much lighter the text should be:

With the orignal colours, hermit is failing the AAA WCAG level:

  https://webaim.org/resources/contrastchecker/?fcolor=C6CDDB&bcolor=494F5C

I chose the first colour making the check pass (contrast > 7.0): #e8eef2.