### PR TITLE
Fix behaviour of auto-hide header

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -34,7 +34,7 @@ let header = document.getElementById('site-header');
 let lastScrollPosition = window.pageYOffset;
 
 const autoHideHeader = () => {
-  let currentScrollPosition = window.pageYOffset;
+  let currentScrollPosition = Math.max(window.pageYOffset, 0);
   if (currentScrollPosition > lastScrollPosition) {
     header.classList.remove('slideInUp');
     header.classList.add('slideOutDown');

--- a/resources/_gen/assets/js/js/main.js_d11fe7b62c27961c87ecd0f2490357b9.content
+++ b/resources/_gen/assets/js/js/main.js_d11fe7b62c27961c87ecd0f2490357b9.content
@@ -1,9 +1,0 @@
-const throttle=(callback,limit)=>{let timeoutHandler=null;return()=>{if(timeoutHandler==null){timeoutHandler=setTimeout(()=>{callback();timeoutHandler=null;},limit);}};};const listen=(ele,e,callback)=>{if(document.querySelector(ele)!==null){document.querySelector(ele).addEventListener(e,callback);}}
-let header=document.getElementById('site-header');let lastScrollPosition=window.pageYOffset;const autoHideHeader=()=>{let currentScrollPosition=window.pageYOffset;if(currentScrollPosition>lastScrollPosition){header.classList.remove('slideInUp');header.classList.add('slideOutDown');}else{header.classList.remove('slideOutDown');header.classList.add('slideInUp');}
-lastScrollPosition=currentScrollPosition;}
-let mobileMenuVisible=false;const toggleMobileMenu=()=>{let mobileMenu=document.getElementById('mobile-menu');if(mobileMenuVisible==false){mobileMenu.style.animationName='bounceInRight';mobileMenu.style.webkitAnimationName='bounceInRight';mobileMenu.style.display='block';mobileMenuVisible=true;}else{mobileMenu.style.animationName='bounceOutRight';mobileMenu.style.webkitAnimationName='bounceOutRight'
-mobileMenuVisible=false;}}
-const showImg=()=>{document.querySelector('.bg-img').classList.add('show-bg-img');}
-const hideImg=()=>{document.querySelector('.bg-img').classList.remove('show-bg-img');}
-const toggleToc=()=>{document.getElementById('toc').classList.toggle('show-toc');}
-if(header!==null){listen('#menu-btn',"click",toggleMobileMenu);listen('#toc-btn',"click",toggleToc);listen('#img-btn',"click",showImg);listen('.bg-img',"click",hideImg);document.querySelectorAll('.post-year').forEach((ele)=>{ele.addEventListener('click',()=>{window.location.hash='#'+ele.id;});});window.addEventListener('scroll',throttle(()=>{autoHideHeader();if(mobileMenuVisible==true){toggleMobileMenu();}},250));}

--- a/resources/_gen/assets/js/js/main.js_d11fe7b62c27961c87ecd0f2490357b9.json
+++ b/resources/_gen/assets/js/js/main.js_d11fe7b62c27961c87ecd0f2490357b9.json
@@ -1,1 +1,0 @@
-{"Target":"js/main.min.784417f5847151f848c339cf0acb13a06cbb648b1483435a28ed4556c4ead69b.js","MediaType":"application/javascript","Data":{"Integrity":"sha256-eEQX9YRxUfhIwznPCssToGy7ZIsUg0NaKO1FVsTq1ps="}}


### PR DESCRIPTION
I fixed an unexpected behavior that the site header is hidden when I scroll a page to the top and then the bounce-scroll occurs in a mobile environment (#76). The followings are what I updated:

- fix the way of getting current scroll position in main.js (in order not to be negative value)
- remove cached main.js to use the new version of it (minifying JS is supported by normal Hugo)

I tested and confirmed that the behavior has been fixed using Safari of the iOS simulator. If something is wrong, please let me know. Thanks!