### PR TITLE
Fix redundant .MediaType.Suffix

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -13,7 +13,7 @@
 	{{- partial "favicons.html" }}
 	<title>{{.Title}}</title>
 	{{ range .AlternativeOutputFormats -}}
-		{{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
+		{{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Title | safeHTML }}
 	{{ end -}}
 	{{ $style := resources.Get "scss/style.scss" | resources.ExecuteAsTemplate "css/style.css" . | toCSS | minify | fingerprint -}}
 	<link rel="stylesheet" href="{{ $style.Permalink }}" {{ printf "integrity=%q" $style.Data.Integrity | safeHTMLAttr }} crossorigin="anonymous">

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -13,7 +13,7 @@
 	{{- partial "favicons.html" }}
 	<title>{{.Title}}</title>
 	{{ range .AlternativeOutputFormats -}}
-		{{ printf `<link rel="%s" type="%s+%s" href="%s" title="%s" />` .Rel .MediaType.Type .MediaType.Suffix .Permalink $.Site.Title | safeHTML }}
+		{{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
 	{{ end -}}
 	{{ $style := resources.Get "scss/style.scss" | resources.ExecuteAsTemplate "css/style.css" . | toCSS | minify | fingerprint -}}
 	<link rel="stylesheet" href="{{ $style.Permalink }}" {{ printf "integrity=%q" $style.Data.Integrity | safeHTMLAttr }} crossorigin="anonymous">


### PR DESCRIPTION
The redundant .MediaType.Suffix results duplicate "xml" in `type="application/rss+xml+xml"` on every page.

Before:
![Screen Shot 2019-09-15 at 2 35 23 AM](https://user-images.githubusercontent.com/7568396/64919581-9bf78400-d761-11e9-93a6-4e1ded988f36.png)

Fixed:
![Screen Shot 2019-09-15 at 2 41 18 AM](https://user-images.githubusercontent.com/7568396/64919661-512a3c00-d762-11e9-9a83-a5cf7cb98431.png)
