### PR TITLE
add meta description for google lighthouse

### DIFF
--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -2,6 +2,7 @@
 title: "{{ replace .Name "-" " " | title }}"
 date: {{ .Date }}
 draft: true
+description:
 comments: false
 images:
 ---

--- a/archetypes/posts.md
+++ b/archetypes/posts.md
@@ -2,6 +2,7 @@
 title: "{{ replace .Name "-" " " | title }}"
 date: {{ .Date }}
 draft: true
+description:
 toc: false
 images:
 tags: 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -9,6 +9,7 @@
 	<meta name="theme-color" content="{{.}}">
 	<meta name="msapplication-TileColor" content="{{.}}">
 	{{- end }}
+	<meta name="description" content="{{.Description | default .Site.Params.Description}}">
 	{{- partial "structured-data.html" . }}
 	{{- partial "favicons.html" }}
 	<title>{{.Title}}</title>


### PR DESCRIPTION
This adds a meta description to all websites for satisfying Google.
It also allows setting a "description" tag in every blog post for making it easier for Google to find these blog articles.

This is supposed to fix #119