### PR TITLE
Add Fathom analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,19 @@ If that's not enough, you can see [Overriding templates](#overriding-templates) 
 * Keep your regular pages in the `content` folder. To create a new page, run `hugo new page-title.md`
 * Keep your blog posts in the `content/posts` folder. To create a new post, run `hugo new posts/post-title.md`
 
+### Analytics
+
+While using Google Analytics is implemented in Hugo by default this template also can be used with [Fathom Analytics](https://usefathom.com/).
+
+In your `config.toml` you can specify your _siteID_ and, if you self-hosting, the tracker URL.
+
+```yaml
+[params.fathomAnalytics]
+  siteID = "ABCDE"
+  # Default value is cdn.usefathom.com, overwrite this if you are self-hosting
+  # serverURL = "analytics.example.com"
+```
+
 ### More customizations
 
 #### Overriding templates

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -13,6 +13,11 @@ enableEmoji = true  # Shorthand emojis in content files - https://gohugo.io/func
 # googleAnalytics = "UA-123-45"
 # disqusShortname = "yourdiscussshortname"
 
+[params.fathomAnalytics]
+  # siteID = "ABCDE"
+  # Default value is cdn.usefathom.com, overwrite this if you are self-hosting
+  # serverURL = "analytics.example.com"
+
 [author]
   name = "John Doe"
 

--- a/layouts/partials/analytics.html
+++ b/layouts/partials/analytics.html
@@ -1,1 +1,5 @@
 {{ template "_internal/google_analytics_async.html" . }}
+
+{{ if and .Site.Params.fathomAnalytics .Site.Params.fathomAnalytics.siteID }}
+    {{- partial "analytics/fathom" . -}}
+{{ end }}

--- a/layouts/partials/analytics/fathom.html
+++ b/layouts/partials/analytics/fathom.html
@@ -1,0 +1,13 @@
+<script>
+(function(f, a, t, h, o, m){
+	a[h]=a[h]||function(){
+		(a[h].q=a[h].q||[]).push(arguments)
+	};
+	o=f.createElement('script'),
+	m=f.getElementsByTagName('script')[0];
+	o.async=1; o.src=t; o.id='fathom-script';
+	m.parentNode.insertBefore(o,m)
+})(document, window, '//{{ .Site.Params.fathomAnalytics.serverURL | default "cdn.usefathom.com" }}/tracker.js', 'fathom');
+fathom('set', 'siteId', '{{ .Site.Params.fathomAnalytics.siteID }}');
+fathom('trackPageview');
+</script>

--- a/theme.toml
+++ b/theme.toml
@@ -9,6 +9,7 @@ features = [
   "featured image",
   "social icons",
   "google analytics",
+  "fathom analytics",
   "disqus"
 ]
 min_version = 0.43


### PR DESCRIPTION
This PR adds the option to use [Fathom Analytics](https://usefathom.com) for analytics. It fixes #125.