### PR TITLE
Update code-copy.js

### DIFF
--- a/assets/js/code-copy.js
+++ b/assets/js/code-copy.js
@@ -36,7 +36,11 @@
     var codeEl = containerEl.firstElementChild;
     copyBtn.addEventListener('click', function() {
       try {
-        var selection = selectText(codeEl);
+        if(codeEl.firstElementChild instanceof HTMLTableElement) {
+          var selection = selectText(codeEl.firstElementChild.firstElementChild.firstElementChild.lastElementChild);
+        } else {
+          var selection = selectText(codeEl);
+        }
         document.execCommand('copy');
         selection.removeAllRanges();
 


### PR DESCRIPTION
Copy action copies line number along with code block. This change is to support copy if `linenos=table`